### PR TITLE
Change mixer_path.xml file path to vendor

### DIFF
--- a/audio_hw.c
+++ b/audio_hw.c
@@ -1038,7 +1038,7 @@ static int adev_open(const hw_module_t* module, const char* name,
     adev->hw_device.dump = adev_dump;
     adev->hw_device.get_microphones = adev_get_microphones;
 
-    sprintf(mixer_path, "/system/etc/mixer_paths_%d.xml", card);
+    sprintf(mixer_path, "/vendor/etc/mixer_paths_%d.xml", card);
     adev->ar = audio_route_init(card, mixer_path);
     if (!adev->ar) {
         ALOGE("%s: Failed to init audio route controls for card %d, aborting.",


### PR DESCRIPTION
mixer_path.xml file is vendor specific, need to be moved
to vendor partition.

Tracked-On: OAM-76659
Signed-off-by: Karan Patidar <karan.patidar@intel.com>